### PR TITLE
Fix wrong types in tests.

### DIFF
--- a/internal/crawler/crawler_test.go
+++ b/internal/crawler/crawler_test.go
@@ -176,7 +176,7 @@ func newTestServer(t *testing.T) *httptest.Server {
 func TestNewCrawler(t *testing.T) {
 	cfg := &config.Config{
 		UserAgent:      "custom-agent",
-		AllowedDomains: "example.com",
+		AllowedDomains: []string{"example.com"},
 		DisallowedURLFilters: []*regexp.Regexp{
 			regexp.MustCompile(".*disallowed.*"),
 		},
@@ -265,7 +265,7 @@ func TestRun(t *testing.T) {
 	// Create a new crawler instance
 	cfg := &config.Config{
 		Site:           ts.URL + "/sitemap.xml",
-		AllowedDomains: hostname,
+		AllowedDomains: []string{hostname},
 		DisallowedURLFilters: []*regexp.Regexp{
 			regexp.MustCompile("/disallowed"),
 		},


### PR DESCRIPTION
`Config.AllowedDomains` is a slice of strings, not a string. These tests couldn't have ever passed 🙃

Fixing now cos it's blocking updates for critical fixes to the net library such as #4.