### PR TITLE
Ignore visiting links that are only fragments

### DIFF
--- a/internal/crawler/crawler.go
+++ b/internal/crawler/crawler.go
@@ -7,6 +7,7 @@ import (
 	"mirrorer/internal/config"
 	"mirrorer/internal/file"
 	"net/http"
+	"strings"
 
 	"github.com/gocolly/colly/v2"
 	"github.com/rs/zerolog/log"
@@ -94,6 +95,10 @@ func htmlHandler(e *colly.HTMLElement) {
 		link = e.Attr("href")
 	case "img", "script":
 		link = e.Attr("src")
+	}
+
+	if strings.HasPrefix(link, "#") {
+		return
 	}
 
 	err := e.Request.Visit(link)

--- a/internal/crawler/crawler.go
+++ b/internal/crawler/crawler.go
@@ -96,14 +96,14 @@ func htmlHandler(e *colly.HTMLElement) {
 		link = e.Attr("src")
 	}
 
-	err := e.Request.Visit(e.Request.AbsoluteURL(link))
+	err := e.Request.Visit(link)
 	if err != nil && !isForbiddenURLError(err) {
 		log.Error().Err(err).Msg("Error attempting to visit link")
 	}
 }
 
 func xmlHandler(e *colly.XMLElement) {
-	err := e.Request.Visit(e.Request.AbsoluteURL(e.Text))
+	err := e.Request.Visit(e.Text)
 	if err != nil && !isForbiddenURLError(err) {
 		log.Error().Err(err).Msg("Error attempting to visit link")
 	}
@@ -120,7 +120,7 @@ func responseHandler(r *colly.Response) {
 		urls := file.FindCssUrls(r.Body)
 
 		for _, url := range urls {
-			err := r.Request.Visit(r.Request.AbsoluteURL(url))
+			err := r.Request.Visit(url)
 			if err != nil && !isForbiddenURLError(err) {
 				log.Error().Err(err).Msg("Error attempting to visit link")
 			}


### PR DESCRIPTION
We don't need to try and attempt to visit links that are fragments to the same page. We also don't need to call AbsoluteURL as this is already done in the Visit method of a request.