### PR TITLE
Minor Dockerfile improvements.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,20 +2,25 @@ ARG go_registry=""
 ARG go_version=1.22
 ARG go_tag_suffix=-alpine
 
-FROM ${go_registry}golang:${go_version}${go_tag_suffix} AS builder
-ARG TARGETARCH TARGETOS
-ARG GOARCH=$TARGETARCH GOOS=$TARGETOS
+
+FROM --platform=$TARGETPLATFORM ${go_registry}golang:${go_version}${go_tag_suffix} AS builder
+ARG TARGETARCH
+ARG TARGETOS
+ARG GOARCH=$TARGETARCH
+ARG GOOS=$TARGETOS
 ARG CGO_ENABLED=0
-ARG GOEXPERIMENT=loopvar
+ARG GOFLAGS="-trimpath"
+ARG go_ldflags="-s -w"
 
 WORKDIR /src
 COPY go.mod go.sum ./
 RUN go mod download
 
 COPY . ./
-RUN go build -o /bin/govuk-mirror cmd/main.go
+RUN go build -o /bin/govuk-mirror -ldflags="$go_ldflags" cmd/main.go
 
-FROM scratch
+
+FROM --platform=$TARGETPLATFORM scratch
 COPY --from=builder /bin/govuk-mirror /bin/govuk-mirror
 COPY --from=builder /usr/share/ca-certificates /usr/share/ca-certificates
 COPY --from=builder /etc/ssl /etc/ssl


### PR DESCRIPTION
- Avoid iffy `ARG x y` syntax.
- Set ldflags for release build.
- Clean up GOEXPERIMENT=loopvar; it's always on in Go 1.22.
- Run arm64 builds on arm64 (at least for now, since that's what our reusable build workflow assumes).

Tested: builds locally.