### PR TITLE
Add security scans to CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,14 @@ on:
   workflow_dispatch:
 
 jobs:
+  codeql-sast:
+    name: CodeQL SAST scan
+    uses: alphagov/govuk-infrastructure/.github/workflows/codeql-analysis.yml@main
+    permissions:
+      security-events: write
+  dependency-review:
+    name: Dependency Review scan
+    uses: alphagov/govuk-infrastructure/.github/workflows/dependency-review.yml@main
   test:
     name: Test Go
     runs-on: ubuntu-latest


### PR DESCRIPTION
Add security scans.

https://trello.com/c/cngUG1UA/3572-add-security-scans-to-repos-that-currently-lack-them-3