### PR TITLE
✨ Add Makefile and Fix Recommended Go Lint Error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,4 +12,4 @@ unit_tests:
 	go test -v ./...
 
 update_deps:
-	go get -t -u ./... && go mod tidy && go mod vendor
+	go get -t -u ./... && go mod tidy

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,15 @@
+test: lint unit_tests
+
+lint:
+	@if ! command -v golangci-lint; then \
+		echo "linting uses golangci-lint: you can install it with:\n"; \
+		echo "    brew install golangci-lint\n"; \
+		exit 1; \
+	fi
+	golangci-lint run
+
+unit_tests:
+	go test -v ./...
+
+update_deps:
+	go get -t -u ./... && go mod tidy && go mod vendor

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -54,7 +54,7 @@ func isRequestAllowed(c *colly.Collector, parsedURL *url.URL) bool {
 		}
 	}
 
-	if c.AllowedDomains == nil || len(c.AllowedDomains) == 0 {
+	if len(c.AllowedDomains) == 0 {
 		return true
 	}
 	for _, d := range c.AllowedDomains {


### PR DESCRIPTION
## 👀 Purpose

This PR does two things:
- It adds a Makefile to simplify and standardise operations like running tests, updating dependencies and linting code.
- It also fixes the golangci-lint error below:
```go
> golangci-lint run
internal/client/client.go:57:5: S1009: should omit nil check; len() for []string is defined
as zero (gosimple)
        if c.AllowedDomains == nil || len(c.AllowedDomains) == 0 {
           ^
```

This error appears as both the allowed domains and the length of the allowed domains are the same.

## ♻️ What's changed

- Removed the or statement in an if condition.
- Added a new file to perform make statements.