### PR TITLE
⬆️ Bump the golangci-lint-action to v8.0.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,13 +35,16 @@ jobs:
           GOEXPERIMENT: loopvar
   lint:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
-      - uses: golangci/golangci-lint-action@v6
+      - uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8.0.0
         with:
-          version: v1.60
+          version: v2.1.6
           # caching issues, see: https://github.com/golangci/golangci-lint-action/issues/244#issuecomment-1052190775
           skip-cache: true

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"fmt"
 	"os"
 	"regexp"
 	"testing"
@@ -56,8 +57,12 @@ func TestNewConfig(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			// Set environment variables
 			for k, v := range test.envVars {
-				os.Setenv(k, v)
-				defer os.Unsetenv(k) // Clean up
+				_ = os.Setenv(k, v)
+				defer func() {
+					if err := os.Unsetenv(k); err != nil {
+						fmt.Println("Error when unsetting:", err)
+					}
+				}()
 			}
 
 			cfg, err := NewConfig()

--- a/internal/crawler/crawler_test.go
+++ b/internal/crawler/crawler_test.go
@@ -1,6 +1,7 @@
 package crawler
 
 import (
+	"fmt"
 	"mirrorer/internal/config"
 	"mirrorer/internal/file"
 	"mirrorer/internal/mime"
@@ -298,7 +299,11 @@ func TestRun(t *testing.T) {
 	cr, err := NewCrawler(cfg)
 	assert.NoError(t, err)
 
-	defer os.RemoveAll(hostname)
+	defer func() {
+		if err := os.RemoveAll(hostname); err != nil {
+			fmt.Println("Error when removing:", err)
+		}
+	}()
 
 	cr.Run()
 

--- a/internal/file/file.go
+++ b/internal/file/file.go
@@ -77,7 +77,7 @@ func GenerateFilePath(u *url.URL, contentType string) (string, error) {
 	existingExtenion := filepath.Ext(lastSegment)
 
 	if len(extensions) == 0 && existingExtenion == "" {
-		return "", fmt.Errorf("Error determining content type")
+		return "", fmt.Errorf("error determining content type")
 	}
 
 	if len(extensions) > 0 && !slices.Contains(extensions, existingExtenion) {

--- a/internal/file/file_test.go
+++ b/internal/file/file_test.go
@@ -68,7 +68,7 @@ func TestGenerateFilePathTableDriven(t *testing.T) {
 		{"https://example.com/foo.csv", "text/csv", "example.com/foo.csv", nil},
 		{"https://example.com/foo.csv/preview", "text/html", "example.com/foo.csv/preview.html", nil},
 		{"https://example.com/style.css", "text/css", "example.com/style.css", nil},
-		{"https://example.com/foo", "text/blah", "", errors.New("Error determining content type")},
+		{"https://example.com/foo", "text/blah", "", errors.New("error determining content type")},
 		{"https://example.com/foo", "", "", errors.New("error determining content type")},
 		{"https://example.com/foo.cy", "text/html", "example.com/foo.cy.html", nil},
 		{"https://example.com/foo.html", "text/html", "example.com/foo.html", nil},

--- a/internal/file/file_test.go
+++ b/internal/file/file_test.go
@@ -2,6 +2,7 @@ package file
 
 import (
 	"errors"
+	"fmt"
 	"net/url"
 	"os"
 	"testing"
@@ -45,11 +46,15 @@ func TestSave(t *testing.T) {
 	if string(content) != string(body) {
 		t.Errorf("file to contain %v, got %v", body, content)
 	}
-	defer os.RemoveAll("example.com")
+	defer func() {
+		if err := os.RemoveAll("example.com"); err != nil {
+			fmt.Println("Error when removing:", err)
+		}
+	}()
 }
 
 func TestGenerateFilePathTableDriven(t *testing.T) {
-	var tests = []struct {
+	tests := []struct {
 		url, contentType string
 		want             string
 		wantErr          error

--- a/internal/file/file_test.go
+++ b/internal/file/file_test.go
@@ -69,7 +69,7 @@ func TestGenerateFilePathTableDriven(t *testing.T) {
 		{"https://example.com/foo.csv/preview", "text/html", "example.com/foo.csv/preview.html", nil},
 		{"https://example.com/style.css", "text/css", "example.com/style.css", nil},
 		{"https://example.com/foo", "text/blah", "", errors.New("Error determining content type")},
-		{"https://example.com/foo", "", "", errors.New("Error determining content type")},
+		{"https://example.com/foo", "", "", errors.New("error determining content type")},
 		{"https://example.com/foo.cy", "text/html", "example.com/foo.cy.html", nil},
 		{"https://example.com/foo.html", "text/html", "example.com/foo.html", nil},
 		{"https://example.com/foo//bar", "text/html", "example.com/foo/bar.html", nil},


### PR DESCRIPTION
## 👀 Purpose

- This PR bumps the golangci-lint-action to v8.0.0 using its commit hash. It also fixes a number of golangci-lint-action errors relating to error handling.