### PR TITLE
📝 Use origin rather than govuk site

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This is used by GOV.UK to populate mirrors hosted by AWS S3 and GCP Storage.
 Configuration is handled through environment variables as listed below:
 
 - SITE: Specifies the starting URL for the crawler.
-    - Example: `SITE=https://www.gov.uk`
+    - Example: `SITE=https://www-origin.publishing.service.gov.uk`
 - ALLOWED_DOMAINS: A comma-separated list of hostnames permitted to be crawled.
     - Example: `ALLOWED_DOMAINS=domain1.com,domain2.com`
 - USER_AGENT: Customizes the user agent for requests. Defaults to `govukbot` if not specified.
@@ -18,7 +18,7 @@ Configuration is handled through environment variables as listed below:
 - CONCURRENCY: Controls the number of concurrent requests, useful for controlling request rate.
     - Example: `CONCURRENCY=10`
 - URL_RULES: A comma-separated list of regex patterns matching URLs that the crawler should crawl. All other URLs will be avoided.
-    - Example: `URL_RULES=https://www.gov.uk/.*`
+    - Example: `URL_RULES=https://www-origin.publishing.service.gov.uk/.*`
 - DISALLOWED_URL_RULES: A comma-separated list of regex patterns matching URLs that the crawler should avoid.
     - Example: `DISALLOWED_URL_RULES=/search/.*,/government/.*\.atom`
 


### PR DESCRIPTION
This mitigates a very small risk that we end up scraping the mirrors
