### PR TITLE
✨ Add Crawler Validation with Tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ Configuration is handled through environment variables as listed below:
     - Example: `URL_RULES=https://www-origin.publishing.service.gov.uk/.*`
 - DISALLOWED_URL_RULES: A comma-separated list of regex patterns matching URLs that the crawler should avoid.
     - Example: `DISALLOWED_URL_RULES=/search/.*,/government/.*\.atom`
+- SKIP_VALIDATION: Skip domain accessibility validation before crawling. Useful for offline testing.
+    - Example: `SKIP_VALIDATION=true`
 
 ## How to deploy
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -17,8 +17,11 @@ func main() {
 	cfg := initConfig()
 
 	// Validate that the SITE URL and allowed domains are accessible before crawling
-	err := crawler.ValidateCrawlerConfig(cfg, 10*time.Second)
-	checkError(err, "Configuration validation failed")
+	// Skip validation if SKIP_VALIDATION=true for offline testing
+	if !cfg.SkipValidation {
+		err := crawler.ValidateCrawlerConfig(cfg, 10*time.Second)
+		checkError(err, "Configuration validation failed")
+	}
 
 	cr, err := crawler.NewCrawler(cfg)
 	checkError(err, "Error creating new crawler")

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -5,6 +5,7 @@ import (
 	"mirrorer/internal/crawler"
 	"mirrorer/internal/mime"
 	"os"
+	"time"
 
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
@@ -14,6 +15,10 @@ func main() {
 	initLogger()
 	initMime()
 	cfg := initConfig()
+
+	// Validate that the SITE URL and allowed domains are accessible before crawling
+	err := crawler.ValidateCrawlerConfig(cfg, 10*time.Second)
+	checkError(err, "Configuration validation failed")
 
 	cr, err := crawler.NewCrawler(cfg)
 	checkError(err, "Error creating new crawler")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -15,6 +15,7 @@ type Config struct {
 	Concurrency          int               `env:"CONCURRENCY" envDefault:"10"`
 	URLFilters           []*regexp.Regexp  `env:"URL_RULES" envSeparator:","`
 	DisallowedURLFilters []*regexp.Regexp  `env:"DISALLOWED_URL_RULES" envSeparator:","`
+	SkipValidation       bool              `env:"SKIP_VALIDATION" envDefault:"false"`
 }
 
 func NewConfig() (*Config, error) {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -18,8 +18,9 @@ func TestNewConfig(t *testing.T) {
 		{
 			name: "defaults",
 			expected: &Config{
-				UserAgent:   "govuk-mirror-bot",
-				Concurrency: 10,
+				UserAgent:      "govuk-mirror-bot",
+				Concurrency:    10,
+				SkipValidation: false,
 			},
 		},
 		{
@@ -32,6 +33,7 @@ func TestNewConfig(t *testing.T) {
 				"CONCURRENCY":          "20",
 				"URL_RULES":            "rule1,rule2",
 				"DISALLOWED_URL_RULES": "rule3,rule4",
+				"SKIP_VALIDATION":      "true",
 			},
 			expected: &Config{
 				Site:           "example.com",
@@ -49,6 +51,7 @@ func TestNewConfig(t *testing.T) {
 					regexp.MustCompile("rule3"),
 					regexp.MustCompile("rule4"),
 				},
+				SkipValidation: true,
 			},
 		},
 	}

--- a/internal/crawler/validation.go
+++ b/internal/crawler/validation.go
@@ -3,11 +3,10 @@ package crawler
 import (
 	"context"
 	"fmt"
+	"mirrorer/internal/config"
 	"net/http"
 	"net/url"
 	"time"
-
-	"mirrorer/internal/config"
 )
 
 // ValidateCrawlerConfig checks if the configured domains are accessible
@@ -70,8 +69,11 @@ func isDomainAccessible(testURL string, timeout time.Duration) bool {
 	if err != nil {
 		return false
 	}
-	defer resp.Body.Close()
+	defer func() {
+		_ = resp.Body.Close()
+	}()
 
 	// Consider 2xx and 3xx status codes as accessible
 	return resp.StatusCode >= 200 && resp.StatusCode < 400
 }
+

--- a/internal/crawler/validation.go
+++ b/internal/crawler/validation.go
@@ -1,0 +1,77 @@
+package crawler
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"time"
+
+	"mirrorer/internal/config"
+)
+
+// ValidateCrawlerConfig checks if the configured domains are accessible
+// Call this before starting a crawl to catch configuration issues early
+func ValidateCrawlerConfig(cfg *config.Config, timeout time.Duration) error {
+	// Check main site URL
+	if cfg.Site != "" {
+		if !isDomainAccessible(cfg.Site, timeout) {
+			return &DomainNotAccessibleError{Domain: cfg.Site}
+		}
+	}
+
+	// Check all allowed domains
+	for _, domain := range cfg.AllowedDomains {
+		testURL := "https://" + domain
+		if !isDomainAccessible(testURL, timeout) {
+			return &DomainNotAccessibleError{Domain: domain}
+		}
+	}
+
+	return nil
+}
+
+// DomainNotAccessibleError indicates a domain is not accessible
+type DomainNotAccessibleError struct {
+	Domain string
+}
+
+func (e *DomainNotAccessibleError) Error() string {
+	return fmt.Sprintf("domain not accessible: %s (hint: www-origin.publishing.service.gov.uk is not externally accessible, use www.gov.uk instead)", e.Domain)
+}
+
+// isDomainAccessible checks if a domain responds to HTTP requests
+func isDomainAccessible(testURL string, timeout time.Duration) bool {
+	parsedURL, err := url.Parse(testURL)
+	if err != nil {
+		return false
+	}
+
+	client := &http.Client{
+		Timeout: timeout,
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			// Allow redirects but limit to 5
+			if len(via) >= 5 {
+				return http.ErrUseLastResponse
+			}
+			return nil
+		},
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, "HEAD", parsedURL.String(), nil)
+	if err != nil {
+		return false
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return false
+	}
+	defer resp.Body.Close()
+
+	// Consider 2xx and 3xx status codes as accessible
+	return resp.StatusCode >= 200 && resp.StatusCode < 400
+}

--- a/internal/crawler/validation_test.go
+++ b/internal/crawler/validation_test.go
@@ -1,0 +1,80 @@
+package crawler
+
+import (
+	"testing"
+	"time"
+
+	"mirrorer/internal/config"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestValidateCrawlerConfig ensures that the configured domains are accessible
+// before starting a crawl, preventing runtime failures from inaccessible domains
+func TestValidateCrawlerConfig(t *testing.T) {
+	tests := []struct {
+		name           string
+		site           string
+		allowedDomains []string
+		expectError    bool
+		description    string
+	}{
+		{
+			name:           "accessible domain",
+			site:           "https://www.gov.uk",
+			allowedDomains: []string{"www.gov.uk"},
+			expectError:    false,
+			description:    "Should pass with accessible domain",
+		},
+		{
+			name:           "inaccessible origin domain",
+			site:           "https://www-origin.publishing.service.gov.uk",
+			allowedDomains: []string{"www-origin.publishing.service.gov.uk"},
+			expectError:    true,
+			description:    "Should fail with inaccessible origin domain",
+		},
+		{
+			name:           "mixed domains",
+			site:           "https://www.gov.uk",
+			allowedDomains: []string{"www.gov.uk", "www-origin.publishing.service.gov.uk"},
+			expectError:    true,
+			description:    "Should fail if any allowed domain is inaccessible",
+		},
+		{
+			name:           "empty site",
+			site:           "",
+			allowedDomains: []string{"www.gov.uk"},
+			expectError:    false,
+			description:    "Should pass with empty site if allowed domains are accessible",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &config.Config{
+				Site:           tt.site,
+				AllowedDomains: tt.allowedDomains,
+				UserAgent:      "test-agent",
+				Concurrency:    1,
+			}
+
+			err := ValidateCrawlerConfig(cfg, 5*time.Second)
+
+			if tt.expectError {
+				assert.Error(t, err, tt.description)
+				// Check that the error message is helpful
+				if err != nil {
+					assert.Contains(t, err.Error(), "not accessible", "Error should indicate domain is not accessible")
+				}
+			} else {
+				assert.NoError(t, err, tt.description)
+			}
+		})
+	}
+}
+
+func TestDomainNotAccessibleError(t *testing.T) {
+	err := &DomainNotAccessibleError{Domain: "www-origin.publishing.service.gov.uk"}
+	expectedMsg := "domain not accessible: www-origin.publishing.service.gov.uk (hint: www-origin.publishing.service.gov.uk is not externally accessible, use www.gov.uk instead)"
+	assert.Equal(t, expectedMsg, err.Error())
+}


### PR DESCRIPTION
This pull request introduces a new feature to validate domain accessibility before starting a crawl, with the option to skip validation for offline testing. It includes updates to the configuration, crawler logic, and associated tests to support this functionality.

### New Domain Validation Feature:

* [`internal/crawler/validation.go`](diffhunk://#diff-2df7805c032b7ee0f794a8682e108415e07ed9629cf645cebf249e408773fb7dR1-R79): Added `ValidateCrawlerConfig` function to check if the configured site and allowed domains are accessible before crawling. Includes a helper function `isDomainAccessible` and a custom error type `DomainNotAccessibleError` for better error reporting.
* [`cmd/main.go`](diffhunk://#diff-c444f711e9191b53952edb65bfd8c644419fc7695c62611dc0fb304b4fb197d6R19-R25): Integrated the validation step into the main function, with a conditional check to skip validation if `SKIP_VALIDATION=true`.

### Configuration Updates:

* [`internal/config/config.go`](diffhunk://#diff-54c7c1af5fa8d5db4dc49f0e8e80e93ba2b1183ba4d5c9e2e5729e6deae6a3cdR18): Added a new configuration field `SkipValidation` to enable skipping domain validation, with a default value of `false`.
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R24-R25): Updated documentation to include the new `SKIP_VALIDATION` environment variable.

### Testing Enhancements:

* [`internal/crawler/validation_test.go`](diffhunk://#diff-96ea4e81f68bfa1c09c45cfb0eefc703b5b3b5b739e4c93f93f76981f6ecf3d4R1-R80): Added unit tests for `ValidateCrawlerConfig` to verify behavior with accessible and inaccessible domains, mixed domains, and empty site configurations. Includes tests for the custom error type.
* [`internal/config/config_test.go`](diffhunk://#diff-78b78dc33eda1ed8d509bfa5a00f66709af57bd30d971cbaec454571a91c3e62R23): Updated configuration tests to validate the behavior of the new `SkipValidation` field. [[1]](diffhunk://#diff-78b78dc33eda1ed8d509bfa5a00f66709af57bd30d971cbaec454571a91c3e62R23) [[2]](diffhunk://#diff-78b78dc33eda1ed8d509bfa5a00f66709af57bd30d971cbaec454571a91c3e62R36) [[3]](diffhunk://#diff-78b78dc33eda1ed8d509bfa5a00f66709af57bd30d971cbaec454571a91c3e62R54)

### Minor Dependency Update:

* [`cmd/main.go`](diffhunk://#diff-c444f711e9191b53952edb65bfd8c644419fc7695c62611dc0fb304b4fb197d6R8): Imported the `time` package to support timeout functionality in domain validation.