### PR TITLE
♻️ Skip validation for asset domains that don't serve root content

### DIFF
--- a/internal/crawler/validation.go
+++ b/internal/crawler/validation.go
@@ -94,7 +94,5 @@ func isDomainAccessibleWithConfig(testURL string, cfg *config.Config, timeout ti
 
 // isAssetDomain checks if a domain is an asset server that doesn't serve content at root
 func isAssetDomain(domain string) bool {
-	// Check for assets.publishing.service.gov.uk and its staging variants
-	return strings.HasPrefix(strings.ToLower(domain), "assets.") && 
-		   strings.HasSuffix(strings.ToLower(domain), ".publishing.service.gov.uk")
+	return strings.HasPrefix(strings.ToLower(domain), "assets.")
 }

--- a/internal/crawler/validation_test.go
+++ b/internal/crawler/validation_test.go
@@ -1,10 +1,9 @@
 package crawler
 
 import (
+	"mirrorer/internal/config"
 	"testing"
 	"time"
-
-	"mirrorer/internal/config"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -27,16 +26,16 @@ func TestValidateCrawlerConfig(t *testing.T) {
 			description:    "Should pass with accessible domain",
 		},
 		{
-			name:           "inaccessible origin domain",
-			site:           "https://www-origin.publishing.service.gov.uk",
-			allowedDomains: []string{"www-origin.publishing.service.gov.uk"},
+			name:           "inaccessible domain",
+			site:           "https://definitely-does-not-exist.example.com",
+			allowedDomains: []string{"definitely-does-not-exist.example.com"},
 			expectError:    true,
-			description:    "Should fail with inaccessible origin domain",
+			description:    "Should fail with inaccessible domain",
 		},
 		{
 			name:           "mixed domains",
 			site:           "https://www.gov.uk",
-			allowedDomains: []string{"www.gov.uk", "www-origin.publishing.service.gov.uk"},
+			allowedDomains: []string{"www.gov.uk", "definitely-does-not-exist.example.com"},
 			expectError:    true,
 			description:    "Should fail if any allowed domain is inaccessible",
 		},
@@ -74,7 +73,8 @@ func TestValidateCrawlerConfig(t *testing.T) {
 }
 
 func TestDomainNotAccessibleError(t *testing.T) {
-	err := &DomainNotAccessibleError{Domain: "www-origin.publishing.service.gov.uk"}
-	expectedMsg := "domain not accessible: www-origin.publishing.service.gov.uk (hint: www-origin.publishing.service.gov.uk is not externally accessible, use www.gov.uk instead)"
+	err := &DomainNotAccessibleError{Domain: "definitely-does-not-exist.example.com"}
+	expectedMsg := "domain not accessible: definitely-does-not-exist.example.com"
 	assert.Equal(t, expectedMsg, err.Error())
 }
+


### PR DESCRIPTION
## 👀 Purpose

 - Fix crawler validation failure when assets domains return 404 at the root path
 - Enable make test-local to work without skipping validation by handling asset servers correctly

## ♻️ What's changed

  - Added isAssetDomain() function to identify asset servers (domains starting with "assets.")
  - Modified ValidateCrawlerConfig() to skip validation for asset domains that don't serve content at the root
  - Updated validation tests to use reliably inaccessible test domains instead of VPN-dependent domains
  - Cleaned up error message to remove outdated hint about www-origin domain

## 📝 Notes

  - Asset servers like assets.publishing.service.gov.uk and assets.staging.publishing.service.gov.uk are designed to serve files
  at specific paths, not at the root
  - A 404 response at the root path is expected behaviour for these domains, so validation should skip them
  - Tests now use definitely-does-not-exist.example.com to ensure consistent failure regardless of VPN status